### PR TITLE
Remove twilight16 feat flag, update twilight-model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ default = ["rustls-native-roots", "macros"]
 songbird = ["songbird-dep"]
 serenity = ["serenity-dep"]
 twilight = ["twilight-model"]
-twilight16 = ["twilight-model-16"]
 
 macros = ["macros-dep"]
 
@@ -100,12 +99,7 @@ default-features = false
 optional = true
 
 [dependencies.twilight-model]
-version = "0.15"
-optional = true
-
-[dependencies.twilight-model-16]
-package = "twilight-model"
-version = "0.16.0-rc"
+version = "0.16"
 optional = true
 
 [dependencies.pyo3]
@@ -148,7 +142,6 @@ package = "lavalink_rs_macros"
 #version = "0.2"
 path = "./lavalink_rs_macros"
 optional = true
-
 
 [build-dependencies]
 version_check = "0.9"


### PR DESCRIPTION
As `twilight-model` 0.16.0 is now stable, the `twilight16` feature flag can be removed[^1] and `twilight-model` updated from 0.15 to 0.16.

[^1]: The assumption is this feature flag was made only to support the **unstable** versions of 0.16.0. If this assumption is wrong and support for both `twilight-model` 0.15 and 0.16 is preferred, this MR can be closed.